### PR TITLE
Help: skip helpless commands

### DIFF
--- a/lib/dev/commands/help.rb
+++ b/lib/dev/commands/help.rb
@@ -10,6 +10,7 @@ module Dev
         Dev::Commands::Registry.resolved_commands.each do |name, klass|
           next if name == 'help'
           puts CLI::UI.fmt("{{command:#{Dev::TOOL_NAME} #{name}}}")
+          next unless klass.respond_to?(:help)
           if help = klass.help
             puts CLI::UI.fmt(help)
           end


### PR DESCRIPTION
Some commands are missing `self.help` methods. Right now, this raises an exception - it should just skip printing the extra text for those commands instead.

Sample backtrace:
```
         2: from /opt/minidev/lib/dev/commands/help.rb:10:in `call'
         1: from /opt/minidev/lib/dev/commands/help.rb:10:in `each'
/opt/minidev/lib/dev/commands/help.rb:13:in `block in call': undefined method `help' for Dev::Commands::Config:Class (NoMethodError)
```