### PR TITLE
Open PR: repos can have -

### DIFF
--- a/lib/dev/commands/open.rb
+++ b/lib/dev/commands/open.rb
@@ -27,7 +27,7 @@ module Dev
       end
 
       def origin_to_url(origin)
-        _, owner, repo = origin.match(%r{(https://|git@)github.com[:/](.+)/(\w+)(\.git)?}).captures
+        _, owner, repo = origin.match(%r{(https://|git@)github.com[:/](.+)/([\w\-]+)(\.git)?}).captures
         "#{GITHUB_URL}/#{owner}/#{repo}"
       end
     end


### PR DESCRIPTION
As reported by a user, some repos `minidev` is used with contain `-`. The current regex parser will read up to the first `-` in the repo name and return that name, which isn't helpful. This updated regex should work fine.