### PR TITLE
Aborts with error if there is no default 'run' configuration

### DIFF
--- a/lib/dev/commands/contextual.rb
+++ b/lib/dev/commands/contextual.rb
@@ -11,7 +11,7 @@ module Dev
         sh, args = if DEFAULT_COMMANDS.include?(name) && cfg.key?(name)
           configstr_run(cfg[name], args)
         else
-          configstr_run(cfg['commands'][name], args)
+          configstr_run(name, cfg['commands'][name], args)
         end
 
         puts("\x1b[1;34mexecuting #{sh}\x1b[0m")
@@ -21,13 +21,15 @@ module Dev
         exec('/bin/bash', '-c', sh, '--', *args)
       end
 
-      def configstr_run(x, args)
+      def configstr_run(name, x, args)
         case x
         when Hash
           if x['subcommands']&.include?(args[0])
             [x['subcommands'][args.shift]['run'], args]
-          else
+          elsif x.include?('run')
             [x['run'], args]
+          else
+            raise(Abort, "#{name} only defines subcommands, but you did not specify one to run.")
           end
         when String
           [x, args]


### PR DESCRIPTION
If a custom command has subcommands and one is not specified when the
command is run, then the default (specified in the `run` key) should
be executed. If that doesn't exist, tell the user they've made a
mistake.