### PR TITLE
Ignore organization name when fuzzy-finding in CD

### DIFF
--- a/lib/dev/commands/cd.rb
+++ b/lib/dev/commands/cd.rb
@@ -12,10 +12,13 @@ module Dev
       def call(args, _name)
         raise(Abort, 'one arg required') unless args.size == 1
         arg = args.first
-        scores, stat = CLI::Kit::System.capture2(FZY, '--show-matches', arg, stdin_data: avail.join("\n"))
+        scores, stat = CLI::Kit::System.capture2(FZY, '--show-matches', arg, stdin_data: avail.values.join("\n"))
         raise(Abort, 'fzy failed') unless stat.success?
 
-        target = File.expand_path(File.join(GITHUB_ROOT, scores.lines.first))
+        matching_repo = scores.lines.first.strip
+        matching_owner = avail.select { |owner, repos| repos.include?(matching_repo) }.keys.first
+
+        target = File.expand_path(File.join(GITHUB_ROOT, matching_owner, matching_repo))
         IO.new(9).puts("chdir:#{target}")
       end
 
@@ -25,13 +28,13 @@ module Dev
           File.directory?(File.join(File.expand_path(GITHUB_ROOT), f))
         end
 
-        owners.flat_map do |owner|
+        owners.each_with_object({}) do |owner, hash|
           repos = Dir.entries(File.expand_path(File.join(GITHUB_ROOT, owner))) - %w(. ..)
           repos = repos.select do |f|
             File.directory?(File.join(File.expand_path(File.join(GITHUB_ROOT, owner)), f))
           end
 
-          repos.map { |r| File.join(owner, r) }
+          hash[owner] = repos
         end
       end
 


### PR DESCRIPTION
Given a repository structure of `Shopify/shopify` and `Shopify/web`, and an input of "shopify", the old implementation of `dev cd shopify` would always pick web. Why? The strings that were actually passed to fzy were `Shopify/web` and `Shopify/shopify`. Because `Shopify/web` is shorter, the matching score was slightly higher. This change modifies CD to only look at the individual repository names for `cd`'ing, rather than the full string. That way, `dev cd shopify` will prioritize repositories named `shopify` over organizations that are named `Shopify`.

In short, `dev cd shopify` will actually take us to the Shopify/shopify repository now when web is also cloned.

---

Illustration of the problem:

```
$ for x in Shopify/shopify Shopify/web Shopify/storefront-renderer; do echo $x; done | fzy --show-matches=shopify --show-scores
6.880000	Shopify/web
6.860000	Shopify/shopify
6.800000	Shopify/storefront-renderer
```