### PR TITLE
Explicitly call builtin `ps`

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -1,4 +1,4 @@
-case "$(basename "$(ps -p $$ | awk 'NR > 1 { sub(/^-/, "", $4); print $4 }')")" in
+case "$(basename $SHELL)" in
   zsh)  __minidev_source_dir="$(dirname "$0:A")" ;;
   bash) __minidev_source_dir="$(builtin cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" ;;
   *) echo "unsupported shell" >&2 ; return 1 ;;

--- a/dev.sh
+++ b/dev.sh
@@ -1,4 +1,4 @@
-case "$(basename $SHELL)" in
+case "$(basename "$(\ps -p $$ | awk 'NR > 1 { sub(/^-/, "", $4); print $4 }')")" in
   zsh)  __minidev_source_dir="$(dirname "$0:A")" ;;
   bash) __minidev_source_dir="$(builtin cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" ;;
   *) echo "unsupported shell" >&2 ; return 1 ;;


### PR DESCRIPTION
The original code is printing an empty string and causing minidev not to initialize, using macOS 12.4, iterm 3.14.6, zsh 5.8.1 (x86_64-apple-darwin21.0) - all latest at time of writing.

Happy to provide more info, but/in any case, thanks for this! :D 