### PR TITLE
Populate command env with 'env' config key

### DIFF
--- a/lib/dev/commands/contextual.rb
+++ b/lib/dev/commands/contextual.rb
@@ -18,7 +18,7 @@ module Dev
 
         sh.concat(' "$@"') if sh.lines.size == 1 && sh !~ /\$[@\*]/
         sh = %Q{runcmd() {\n#{sh}\n}\nruncmd "$@"}
-        exec('/bin/bash', '-c', sh, '--', *args)
+        exec(cmd_env(cfg), '/bin/bash', '-c', sh, '--', *args)
       end
 
       def configstr_run(name, x, args)
@@ -40,6 +40,10 @@ module Dev
 
       def self.help
         'TODO'
+      end
+
+      def cmd_env(cfg)
+        return ENV.to_h.merge(cfg['env'] || {})
       end
     end
   end


### PR DESCRIPTION
I don't know what else might be happening with `env` in `dev` so I don't know if this is sufficient for parity, but it does solve the immediate problem of subcommands that depend on having `env` setup properly.

I verified the behavior with this `dev.yml` addition

```yaml
env:
  DEV_ENV_TEST: '1'
  EDITOR: ~

commands:
  env-test:
    sh -c '
      [ x$DEV_ENV_TEST = x1 ] || { echo "var not set"; exit 1; };
      [ x${EDITOR-unset} = xunset ] || { echo "var not unset"; exit 1; };
      echo ok'
```

but wasn't sure if we wanted to include this or start adding tests.
What do you think?