### PR TITLE
Make dev cd fail more gracefully

### DIFF
--- a/lib/dev/commands/cd.rb
+++ b/lib/dev/commands/cd.rb
@@ -14,6 +14,7 @@ module Dev
         arg = args.first
         scores, stat = CLI::Kit::System.capture2(FZY, '--show-matches', arg, stdin_data: avail.join("\n"))
         raise(Abort, 'fzy failed') unless stat.success?
+        raise(Abort, "no such file or directory: #{arg}") if scores.empty?
 
         target = File.expand_path(File.join(GITHUB_ROOT, scores.lines.first))
         IO.new(9).puts("chdir:#{target}")


### PR DESCRIPTION
A quick one-liner to make `dev cd` behave more nicely if the directory can't be found.

Before:

```
➜  minidev git:(master) ✗ dev cd asdfsdf
This command ran with ID: 93201
Please include this information in any issues/report along with relevant logs
/Users/andrew/src/github.com/burke/minidev/lib/dev/commands/cd.rb:19:in `join': no implicit conversion of nil into String (TypeError)
	from /Users/andrew/src/github.com/burke/minidev/lib/dev/commands/cd.rb:19:in `call'
	from /Users/andrew/src/github.com/burke/minidev/vendor/deps/cli-kit/lib/cli/kit/base_command.rb:24:in `block in call'
        ...
```

After:

```
➜  minidev git:(master) ✗ dev cd asfadsfasdf
no such file or directory: asfadsfasdf
```