### PR TITLE
Fix processing of 'default' commands

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,4 +1,4 @@
 up:
   - ruby: 2.5.6
 
-build: bin/update-deps
+build: script/update-deps

--- a/lib/dev/commands/contextual.rb
+++ b/lib/dev/commands/contextual.rb
@@ -9,7 +9,7 @@ module Dev
         cfg = Project.current.config
 
         sh, args = if DEFAULT_COMMANDS.include?(name) && cfg.key?(name)
-          configstr_run(cfg[name], args)
+          configstr_run(name, cfg[name], args)
         else
           configstr_run(name, cfg['commands'][name], args)
         end


### PR DESCRIPTION
Tiny fix to prevent the following error from being raised when running one of the "default" commands like `dev build`:

```
➜  minidev git:(master) ✗ dev build
This command ran with ID: 61123
Please include this information in any issues/report along with relevant logs
/Users/andrew/src/github.com/burke/minidev/lib/dev/commands/contextual.rb:24:in `configstr_run': wrong number of arguments (given 2, expected 3) (ArgumentError)
	from /Users/andrew/src/github.com/burke/minidev/lib/dev/commands/contextual.rb:12:in `call'
	from /Users/andrew/src/github.com/burke/minidev/vendor/deps/cli-kit/lib/cli/kit/base_command.rb:24:in `block in call'
        ...
```