### PR TITLE
add configurable env for GITHUB_ROOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,5 @@ elif [ -f ~/src/github.com/burke/minidev/dev.sh ]; then
   source ~/src/github.com/burke/minidev/dev.sh
 fi
 ```
+
+You can config the default directory for `dev clone` and `dev cd` by calling `dev config set default.github_root <path to directory>`, otherwise it defaults to `~/src/github.com`.

--- a/lib/dev.rb
+++ b/lib/dev.rb
@@ -17,6 +17,7 @@ module Dev
   autoload(:Commands,           'dev/commands')
   autoload(:ContextualResolver, 'dev/contextual_resolver')
   autoload(:Project,            'dev/project')
+  autoload(:Default,            'dev/default')
 
   autocall(:Config)  { CLI::Kit::Config.new(tool_name: TOOL_NAME) }
   autocall(:Command) { CLI::Kit::BaseCommand }

--- a/lib/dev/commands/cd.rb
+++ b/lib/dev/commands/cd.rb
@@ -6,7 +6,6 @@ module Dev
       basename = RUBY_PLATFORM =~ /darwin/ ? 'fzy_darwin' : 'fzy_linux'
       File.expand_path("vendor/#{basename}", ROOT)
     end
-    GITHUB_ROOT = ENV.fetch('DEV_GITHUB_ROOT', '~/src/github.com')
 
     class Cd < Dev::Command
       def call(args, _name)
@@ -15,20 +14,20 @@ module Dev
         scores, stat = CLI::Kit::System.capture2(FZY, '--show-matches', arg, stdin_data: avail.join("\n"))
         raise(Abort, 'fzy failed') unless stat.success?
 
-        target = File.expand_path(File.join(GITHUB_ROOT, scores.lines.first))
+        target = File.expand_path(File.join(Dev::Default.github_root, scores.lines.first))
         IO.new(9).puts("chdir:#{target}")
       end
 
       def avail
-        owners = Dir.entries(File.expand_path(GITHUB_ROOT)) - %w(. ..)
+        owners = Dir.entries(File.expand_path(Dev::Default.github_root)) - %w(. ..)
         owners = owners.select do |f|
-          File.directory?(File.join(File.expand_path(GITHUB_ROOT), f))
+          File.directory?(File.join(File.expand_path(Dev::Default.github_root), f))
         end
 
         owners.flat_map do |owner|
-          repos = Dir.entries(File.expand_path(File.join(GITHUB_ROOT, owner))) - %w(. ..)
+          repos = Dir.entries(File.expand_path(File.join(Dev::Default.github_root, owner))) - %w(. ..)
           repos = repos.select do |f|
-            File.directory?(File.join(File.expand_path(File.join(GITHUB_ROOT, owner)), f))
+            File.directory?(File.join(File.expand_path(File.join(Dev::Default.github_root, owner)), f))
           end
 
           repos.map { |r| File.join(owner, r) }

--- a/lib/dev/commands/cd.rb
+++ b/lib/dev/commands/cd.rb
@@ -6,7 +6,7 @@ module Dev
       basename = RUBY_PLATFORM =~ /darwin/ ? 'fzy_darwin' : 'fzy_linux'
       File.expand_path("vendor/#{basename}", ROOT)
     end
-    GITHUB_ROOT = '~/src/github.com'
+    GITHUB_ROOT = ENV.fetch('DEV_GITHUB_ROOT', '~/src/github.com')
 
     class Cd < Dev::Command
       def call(args, _name)

--- a/lib/dev/commands/clone.rb
+++ b/lib/dev/commands/clone.rb
@@ -10,7 +10,7 @@ module Dev
         repo = if arg =~ %r{.*/.*}
           arg
         else
-          "#{default_account}/#{arg}"
+          "#{Dev::Default.account}/#{arg}"
         end
         target = File.expand_path("~/src/github.com/#{repo}")
         FileUtils.mkdir_p(File.dirname(target))
@@ -21,12 +21,6 @@ module Dev
 
       def self.help
         'TODO'
-      end
-
-      def default_account
-        account = Dev::Config.get('default', 'account')
-        raise(Abort, 'account/repo both required unless default.account is set in config') unless account
-        account
       end
     end
   end

--- a/lib/dev/default.rb
+++ b/lib/dev/default.rb
@@ -1,0 +1,17 @@
+require 'dev'
+
+module Dev
+    class Default
+        SECTION = "default"
+
+        def self.github_root
+            @@github_root ||= Dev::Config.get(SECTION, "github_root") || "~/src/github.com/"
+        end
+
+        def self.account
+            account = Dev::Config.get(SECTION, 'account')
+            raise(Abort, "account/repo both required unless #{SECTION}.account is set in config") unless account
+            account
+        end
+    end
+end


### PR DESCRIPTION
Adding an environment variable called `DEV_GITHUB_ROOT` so that the GITHUB_ROOT is configurable and isn't always hard coded to `~/src/github.com`.