### PR TITLE
fix: dev clone should use Default.github_root

### DIFF
--- a/lib/dev/commands/clone.rb
+++ b/lib/dev/commands/clone.rb
@@ -12,7 +12,7 @@ module Dev
         else
           "#{Dev::Default.account}/#{arg}"
         end
-        target = File.expand_path("~/src/github.com/#{repo}")
+        target = File.expand_path("#{Dev::Default.github_root}/#{repo}")
         if File.directory?(target)
           IO.new(9).puts("chdir:#{target}")
           return


### PR DESCRIPTION
#15 made the root folder configurable and this PR fixes `dev clone` to use that set value rather than the original hardcoded string.